### PR TITLE
Fix build for zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,10 +9,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "vorbis",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = std.builtin.LinkMode.static,
     });
     lib.linkLibrary(libogg_dep.artifact("ogg"));
     lib.addIncludePath(b.path("include"));


### PR DESCRIPTION
This is going to need https://github.com/andrewrk/libogg/pull/1 to be merged and then `build.zig.zon` updated before it will actually build.